### PR TITLE
All data from a particular type

### DIFF
--- a/pennyworth/client.py
+++ b/pennyworth/client.py
@@ -43,7 +43,8 @@ class AlfredClient(object):
                 if trans_seq == 1:
                     raise AlfredError('Error received from server')
             elif tlv_type != AlfredPacketType.PUSH_DATA or trans_id != tx_id:
-                raise AlfredInvalidResponse('Invalid response received from server')
+                raise AlfredInvalidResponse(
+                    'Invalid response received from server')
             recv_data = bytes(self.sock.recv(tlv_len-4))
             src_mac = recv_data[0:6]
             data_type = recv_data[6]
@@ -52,8 +53,8 @@ class AlfredClient(object):
             data = recv_data[10:]
             if len(data) != data_len:
                 raise AlfredDataError('Failed to receive all data from server. '
-                    'Received {} bytes. Should have received {}'.format(len(data),
-                    data_len))
+                    'Received {} bytes. Should have received {}'
+                    .format(len(data), data_len))
             src_mac = ':'.join(['{:02x}'.format(x) for x in src_mac])
             ret_data[src_mac] = data
             tlv_hdr = bytes(self.sock.recv(4))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,6 +14,7 @@ sock_path = os.path.join(dir_path, 'tmp.sock')
 
 
 class TestClient(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
         try:
@@ -33,13 +34,15 @@ class TestClient(unittest.TestCase):
         self.client = client.AlfredClient(sock_path)
 
     def test_request(self):
-        ret = self.client.request_data(153)
-        self.assertEqual(ret[0], 'aa:bb:cc:dd:ee:ff')
-        self.assertEqual(ret[1], b'\x01\x02\x03\x04\x05\x06')
+        requested_data = self.client.request_data(153)
+        self.assertEqual(len(requested_data), 1)
+        expected_dict = {'aa:bb:cc:dd:ee:ff': b'\x01\x02\x03\x04\x05\x06'}
+        self.assertDictEqual(requested_data, expected_dict)
 
     def test_request_no_data(self):
-        ret = self.client.request_data(255)
-        self.assertIsNone(ret)
+        requested_data = self.client.request_data(255)
+        expected_dict = {}
+        self.assertDictEqual(requested_data, expected_dict)
 
     def test_request_error(self):
         with self.assertRaises(AlfredError):


### PR DESCRIPTION
Small change to the _send_recv function
Previously, only the data of the first ALFRED server that was received by the server was returned by the function, so if multiple servers 'broadcast' data, only the data of 1 server was returned by the function
This change loops until no more data is available, if multiple ALFRED server send data, an array of [key: src_mac, value: data] is returned by the function